### PR TITLE
chore: bump azwi to v0.10.0

### DIFF
--- a/Formula/azwi.rb
+++ b/Formula/azwi.rb
@@ -4,27 +4,27 @@
 class Azwi < Formula
   desc "A utility CLI that helps manage Azure AD Workload Identity and automate error-prone operations:"
   homepage "https://azure.github.io/azure-workload-identity"
-  version "0.8.0"
+  version "0.10.0"
 
   on_macos do
     if Hardware::CPU.intel?
       url "https://github.com/Azure/azure-workload-identity/releases/download/v#{version}/azwi-v#{version}-darwin-amd64.tar.gz"
-      sha256 "5359db2c3e69d082ec3789624e8b7ec529e442e61a3129afad01fa5606e57e06"
+      sha256 "617351e013bda398fa20f31294808c4ebcad6852e38a6306efcffa40cdf9501f"
     end
     if Hardware::CPU.arm?
       url "https://github.com/Azure/azure-workload-identity/releases/download/v#{version}/azwi-v#{version}-darwin-arm64.tar.gz"
-      sha256 "de3278c8449d7e23a3a3defc179cbd8e9c9eac43a06bd067d44d27bc411d37a4"
+      sha256 "47df2867603e4dd02a79f0c4d2d8cb2ece25a5c0ceee7671490f7689bf3e20db"
     end
   end
 
   on_linux do
     if Hardware::CPU.intel?
       url "https://github.com/Azure/azure-workload-identity/releases/download/v#{version}/azwi-v#{version}-linux-amd64.tar.gz"
-      sha256 "93dbca819b2aa44b37a64a928361da68c5b8b720acf88c1371b45050ff4ab248"
+      sha256 "e3d6b8991e408daef7211d92df002ec0937f70951c047d6cbbbd492aed15ba9a"
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
       url "https://github.com/Azure/azure-workload-identity/releases/download/v#{version}/azwi-v#{version}-linux-arm64.tar.gz"
-      sha256 "2e778c35606843a0a78347e7a4d04a639143ab7043cdac53edd058434fa921ad"
+      sha256 "49431833f4756124919b66e79a5702e89c1590271d83d9aa06b0a53bd0a728f9"
     end
   end
 


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

```bash
47df2867603e4dd02a79f0c4d2d8cb2ece25a5c0ceee7671490f7689bf3e20db  azwi-v0.10.0-darwin-arm64.tar.gz
49431833f4756124919b66e79a5702e89c1590271d83d9aa06b0a53bd0a728f9  azwi-v0.10.0-linux-arm64.tar.gz
617351e013bda398fa20f31294808c4ebcad6852e38a6306efcffa40cdf9501f  azwi-v0.10.0-darwin-amd64.tar.gz
6dea0a21c7856b9de3a41285fb3090b63470e2d328058a6ba9fa64cd6d13e13f  azwi-v0.10.0-windows-amd64.zip
e3d6b8991e408daef7211d92df002ec0937f70951c047d6cbbbd492aed15ba9a  azwi-v0.10.0-linux-amd64.tar.gz
```