### PR TITLE
chore: bump azwi to v0.11.0

### DIFF
--- a/Formula/azwi.rb
+++ b/Formula/azwi.rb
@@ -4,27 +4,27 @@
 class Azwi < Formula
   desc "A utility CLI that helps manage Azure AD Workload Identity and automate error-prone operations:"
   homepage "https://azure.github.io/azure-workload-identity"
-  version "0.10.0"
+  version "0.11.0"
 
   on_macos do
     if Hardware::CPU.intel?
       url "https://github.com/Azure/azure-workload-identity/releases/download/v#{version}/azwi-v#{version}-darwin-amd64.tar.gz"
-      sha256 "617351e013bda398fa20f31294808c4ebcad6852e38a6306efcffa40cdf9501f"
+      sha256 "02390dfc079518a482237cd4bd1a9409ff3ba0035857ab42855f1ffe9a0fb605"
     end
     if Hardware::CPU.arm?
       url "https://github.com/Azure/azure-workload-identity/releases/download/v#{version}/azwi-v#{version}-darwin-arm64.tar.gz"
-      sha256 "47df2867603e4dd02a79f0c4d2d8cb2ece25a5c0ceee7671490f7689bf3e20db"
+      sha256 "6bc3adff6d31cd459980c942d6fced58b60b73ece8058d9783d097f5748cd444"
     end
   end
 
   on_linux do
     if Hardware::CPU.intel?
       url "https://github.com/Azure/azure-workload-identity/releases/download/v#{version}/azwi-v#{version}-linux-amd64.tar.gz"
-      sha256 "e3d6b8991e408daef7211d92df002ec0937f70951c047d6cbbbd492aed15ba9a"
+      sha256 "8f64c111e055a6e50ddfca6a5ffe9a2ed807e2a45f658ec0d11024adc08ff2c4"
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
       url "https://github.com/Azure/azure-workload-identity/releases/download/v#{version}/azwi-v#{version}-linux-arm64.tar.gz"
-      sha256 "49431833f4756124919b66e79a5702e89c1590271d83d9aa06b0a53bd0a728f9"
+      sha256 "4c895653f0f5066c1a1e449f504fb44651b0b5d86d1d06bb5fd95316166e6b2c"
     end
   end
 


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

```
02390dfc079518a482237cd4bd1a9409ff3ba0035857ab42855f1ffe9a0fb605  azwi-v0.11.0-darwin-amd64.tar.gz
4c895653f0f5066c1a1e449f504fb44651b0b5d86d1d06bb5fd95316166e6b2c  azwi-v0.11.0-linux-arm64.tar.gz
6274bbc7362d12cc4497e1eb106960335776f90b9badd362742d6665dbc8e02f  azwi-v0.11.0-windows-amd64.zip
6bc3adff6d31cd459980c942d6fced58b60b73ece8058d9783d097f5748cd444  azwi-v0.11.0-darwin-arm64.tar.gz
8f64c111e055a6e50ddfca6a5ffe9a2ed807e2a45f658ec0d11024adc08ff2c4  azwi-v0.11.0-linux-amd64.tar.gz
```